### PR TITLE
Fix generateNuspec and package tasks in Gradle < 4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.betomorrow.gradle
-version=1.1.0
+version=1.1.1

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/XamarinLibraryPlugin.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/XamarinLibraryPlugin.groovy
@@ -70,7 +70,7 @@ class XamarinLibraryPlugin implements Plugin<Project> {
 
                 nuspec.packages.all { p ->
 
-                    def targetNuspecPath = project.file("${p.packageId}.nuspec").path
+                    def targetNuspec = project.file("${p.packageId}.nuspec")
 
                     def generateNuspec = task("generateNuspec${p.name}", 'type': GenerateNuspecTask) {
                         packageId = p.packageId
@@ -86,7 +86,7 @@ class XamarinLibraryPlugin implements Plugin<Project> {
                         releaseNotes = p.releaseNotes
                         copyright = p.copyright
                         tags = p.tags
-                        output = targetNuspecPath
+                        output = targetNuspec
                         dependencies = p.dependencies
                         assemblies = p.assemblies
                         configuration = library.configuration
@@ -94,7 +94,7 @@ class XamarinLibraryPlugin implements Plugin<Project> {
                     generateNuspecTasks.add(generateNuspec)
 
                     def packageTask = task("package${p.name}", dependsOn: ['build', "generateNuspec${p.name}"], 'type': PackageLibraryTask) {
-                        nuspecPath = targetNuspecPath
+                        nuspecPath = targetNuspec.path
                         suffix = p.suffix
                         outputDirectory = NuspecPluginExtension.OUTPUT_DIRECTORY
                     }

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
@@ -2,16 +2,15 @@ package com.betomorrow.gradle.library.tasks
 
 import com.betomorrow.gradle.library.extensions.nuspec.AssemblyTarget
 import com.betomorrow.xamarin.descriptors.project.SymbolsFormat
+import com.betomorrow.xamarin.descriptors.project.XamarinProjectDescriptor
+import com.betomorrow.xamarin.descriptors.solution.SolutionDescriptor
+import com.betomorrow.xamarin.descriptors.solution.SolutionLoader
 import com.betomorrow.xamarin.tools.nuspec.NuSpec
 import com.betomorrow.xamarin.tools.nuspec.NuSpecWriter
 import com.betomorrow.xamarin.tools.nuspec.XmlNuSpecWriter
 import com.betomorrow.xamarin.tools.nuspec.assemblies.Assembly
 import com.betomorrow.xamarin.tools.nuspec.dependencies.Dependency
 import com.betomorrow.xamarin.tools.nuspec.dependencies.DependencySet
-import com.betomorrow.xamarin.descriptors.project.XamarinProjectDescriptor
-import com.betomorrow.xamarin.descriptors.solution.SolutionDescriptor
-import com.betomorrow.xamarin.descriptors.solution.SolutionLoader
-import groovy.sql.InOutParameter
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -27,7 +26,7 @@ class GenerateNuspecTask extends DefaultTask {
     protected SolutionLoader loader = new SolutionLoader()
 
     @OutputFile
-    String output
+    File output
 
     @Input @Optional
     String title
@@ -75,8 +74,22 @@ class GenerateNuspecTask extends DefaultTask {
 
     List<AssemblyTarget> assemblies
 
+    @Input
+    String checkDependencies() {
+        if (dependencies == null) {
+            return null
+        }
+
+        return dependencies.collect { it -> "${it.group}:${it.id}:${it.version}" }.join(",")
+    }
+
+    @Input
+    String checkAssemblies() {
+        return assemblies.collect { it -> "${it.dest}:${it.includes}" }.join(",")
+    }
+
     @TaskAction
-     void generateNuspec() {
+    void generateNuspec() {
         NuSpec nuSpec = new NuSpec()
 
         nuSpec.output = output

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
@@ -76,10 +76,6 @@ class GenerateNuspecTask extends DefaultTask {
 
     @Input
     String checkDependencies() {
-        if (dependencies == null) {
-            return null
-        }
-
         return dependencies.collect { it -> "${it.group}:${it.id}:${it.version}" }.join(",")
     }
 

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/PackageLibraryTask.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/PackageLibraryTask.groovy
@@ -4,22 +4,16 @@ import com.betomorrow.gradle.library.context.PluginContext
 import com.betomorrow.xamarin.tools.nuget.Nuget
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class PackageLibraryTask extends DefaultTask {
 
     protected Nuget nuget = PluginContext.current.nuget
 
-    @Input @Optional
     String nuspecPath
 
-    @Input @Optional
     String suffix
 
-    @OutputDirectory
     String outputDirectory
 
     @TaskAction

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/tools/nuspec/NuSpec.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/tools/nuspec/NuSpec.groovy
@@ -5,8 +5,8 @@ import com.betomorrow.xamarin.tools.nuspec.dependencies.DependencySet
 
 class NuSpec {
 
-    String source
-    String output
+    File source
+    File output
 
     String title
     String packageId
@@ -28,7 +28,7 @@ class NuSpec {
     NuSpec() {
     }
 
-    NuSpec(String source) {
+    NuSpec(File source) {
         this.source = source
     }
 

--- a/shared/xamarin-build-tools/src/test/groovy/com/betomorrow/xamarin/tools/nuspec/NuSpecTest.groovy
+++ b/shared/xamarin-build-tools/src/test/groovy/com/betomorrow/xamarin/tools/nuspec/NuSpecTest.groovy
@@ -14,7 +14,7 @@ class NuSpecTest {
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder()
 
-    def SAMPLE_NUSPEC = FileUtils.getResourcePath('Sample.nuspec').toString()
+    def SAMPLE_NUSPEC = FileUtils.getResourcePath('Sample.nuspec').toFile()
     def output
 
     NuSpec nuspec
@@ -26,7 +26,7 @@ class NuSpecTest {
 
         writer = new XmlNuSpecWriter()
         nuspec = new NuSpec(SAMPLE_NUSPEC)
-        nuspec.output = output.getAbsolutePath()
+        nuspec.output = output
     }
 
     @Test


### PR DESCRIPTION
Using Gradle < 4, generateNuspec and package tasks failed with this error : 
`java.lang.String cannot be cast to java.io.File`

It is caused by `@OutputFile` and `@OutputDirectory` annotations on string properties (Gradle wants file properties instead).

I modified GenerateNuspecTask to use a File as output property. I also check changes of dependencies and assemblies properties to generate a new nuspec when they have been edited.

Finally, I remove annotations on PackageLibraryTask as it prevents the generation of a new package when we compile changed sources with an unchanged nuspec.