### PR TITLE
Update NuGet default version to 4.6.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.betomorrow.gradle
-version=1.1.1
+version=1.2.0

--- a/sample/CrossLib/build.gradle
+++ b/sample/CrossLib/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.betomorrow.gradle:xamarin-library-plugin:0.3.1"
+        classpath "com.betomorrow.gradle:xamarin-library-plugin:1.2.0-SNAPSHOT"
     }
 }
 
@@ -53,10 +53,14 @@ nuspec {
             description = "Sample for nuspec package plugin"
 
             dependencies {
-                dependency "Xamarin.Forms:[1.4.3,)"
-                dependency "Xam.ACME.Commons:[1.0.0,)"
-                dependency "net40:Xamarin.Forms:[1.4.3,)"
-                dependency "net40:Xam.ACME.Commons:[1.0.0,)"
+                "default" {
+                    dependency "Xamarin.Forms:[1.4.3,)"
+                    dependency "Xam.ACME.Commons:[1.0.0,)"
+                }
+
+                "net40" {
+                    baseOn "default"
+                }
             }
 
             assemblies {

--- a/sample/CrossNetStandardLib/build.gradle
+++ b/sample/CrossNetStandardLib/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.betomorrow.gradle:xamarin-library-plugin:1.1.0-SNAPSHOT"
+        classpath "com.betomorrow.gradle:xamarin-library-plugin:1.2.0-SNAPSHOT"
     }
 }
 

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/tools/nuget/NugetBuilder.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/tools/nuget/NugetBuilder.groovy
@@ -10,7 +10,7 @@ import java.nio.file.Paths
 
 class NugetBuilder {
 
-    static final String DEFAULT_NUGET_VERSION = "4.5.1"
+    static final String DEFAULT_NUGET_VERSION = "4.6.2"
 
     private FileCopier filesCopier = new DefaultFileCopier()
 


### PR DESCRIPTION
NuGet current default version 4.5.1 has an issue replacing '+' characters with '%2B' in assembly name and package folders. It could cause package restoration problems when using PackageReference.

The plugin allows us to choose the NuGet version but it could be interesting having a default version without this bug.

Here is the changelog of NuGet 4.6.2 : https://docs.microsoft.com/en-us/nuget/release-notes/nuget-4.6-rtm