### PR TITLE
Add target framework attribute in assembly target of nuspec

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.betomorrow.gradle
-version=1.7.0
+version=1.8.0

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/extensions/nuspec/AssemblyTarget.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/extensions/nuspec/AssemblyTarget.groovy
@@ -6,13 +6,15 @@ import groovy.transform.Canonical
 class AssemblyTarget {
 
     private String _dest
+    private String _target
     private List<String> _includes
 
     AssemblyTarget() {
     }
 
-    AssemblyTarget(dest, includes) {
+    AssemblyTarget(dest, target, includes) {
         this._dest = dest
+        this._target = target
         this._includes = includes
     }
 
@@ -22,6 +24,14 @@ class AssemblyTarget {
 
     def getDest() {
         return _dest
+    }
+
+    def target(String target) {
+        this._target = target
+    }
+
+    def getTarget() {
+        return _target
     }
 
     def includes(String... includes) {

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTask.groovy
@@ -109,7 +109,7 @@ class GenerateNuspecTask extends DefaultTask {
 
         assemblies.each { target ->
             target.includes.each {
-                resolveAssembly(solution, it).forEach { assembly ->
+                resolveAssembly(solution, target.target, it).forEach { assembly ->
                     nuSpec.assemblySet.addAll(new Assembly(assembly, target.dest))
                 }
             }
@@ -118,33 +118,33 @@ class GenerateNuspecTask extends DefaultTask {
         writer.write(nuSpec)
     }
 
-    List<String> resolveAssembly(SolutionDescriptor solution, String name) {
+    List<String> resolveAssembly(SolutionDescriptor solution, String target, String name) {
         XamarinProjectDescriptor pd = solution.getProject(name)
         if (pd == null) {
             return [name]
         }
 
         def assemblies = []
-        assemblies.add(project.file(".").toPath().relativize(pd.getLibraryOutputPath(configuration)).toString())
+        assemblies.add(project.file(".").toPath().relativize(pd.getLibraryOutputPath(configuration, target)).toString())
 
-        def debugSymbolsPath = getSymbolsPath(pd)
+        def debugSymbolsPath = getSymbolsPath(pd, target)
         if (debugSymbolsPath != null) {
             assemblies.add(project.projectDir.toPath().relativize(debugSymbolsPath).toString())
         }
         return assemblies
     }
 
-    private Path getSymbolsPath(XamarinProjectDescriptor pd) {
+    private Path getSymbolsPath(XamarinProjectDescriptor pd, String target) {
         if (!pd.hasDebugSymbols(configuration)) {
             return null
         }
 
-        def path = pd.getSymbolsOutputPath(configuration)
+        def path = pd.getSymbolsOutputPath(configuration, target)
         if (Files.exists(path)) {
             return path
         }
 
-        path = pd.getSymbolsOutputPath(configuration, SymbolsFormat.PDB)
+        path = pd.getSymbolsOutputPath(configuration, target, SymbolsFormat.PDB)
         if (Files.exists(path)) {
             return path
         }

--- a/plugins/xamarin-library-plugin/src/test/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTaskTest.groovy
+++ b/plugins/xamarin-library-plugin/src/test/groovy/com/betomorrow/gradle/library/tasks/GenerateNuspecTaskTest.groovy
@@ -293,7 +293,7 @@ class GenerateNuspecTaskTest extends Specification {
                         target {
                             dest "lib/Xamarin.iOS10"
                             includes "CrossLib.Abstractions",
-                                     "CrossLib.IOS"
+                                    "CrossLib.IOS"
                         }
                     }
                 }
@@ -333,6 +333,47 @@ class GenerateNuspecTaskTest extends Specification {
         assert nuSpecData.assemblySet.contains(new Assembly(Paths.get('CrossLib.IOS/bin/Release/CrossLib.IOS.dll').toString(),
                 'lib/Xamarin.iOS10'))
 
+
+
+    }
+
+    def "should resolve assemblies by project names and target"() {
+        given:
+        NuSpec nuSpecData
+        project.nuspec {
+            packages {
+                SampleLib {
+                    assemblies {
+                        target {
+                            dest "lib/portable-net45+wp8+wpa81"
+                            target "portable-net45+wp8+wpa81"
+                            includes "CrossLib"
+                        }
+
+                        target {
+                            dest "lib/netstandard2.0"
+                            target "netstandard2.0"
+                            includes "CrossLib"
+                        }
+                    }
+                }
+            }
+        }
+
+        when:
+        project.evaluate()
+        task = project.tasks.generateNuspecSampleLib
+        task.writer = writer
+        task.generateNuspec()
+
+        then:
+        1 * writer.write(_) >> { arguments -> nuSpecData = arguments[0] }
+
+        assert nuSpecData.assemblySet.contains(new Assembly(Paths.get('CrossLib/bin/Release/portable-net45+wp8+wpa81/CrossLib.dll').toString(),
+                'lib/portable-net45+wp8+wpa81'))
+
+        assert nuSpecData.assemblySet.contains(new Assembly(Paths.get('CrossLib/bin/Release/netstandard2.0/CrossLib.dll').toString(),
+                'lib/netstandard2.0'))
 
 
     }

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/descriptors/project/XamarinProjectDescriptor.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/descriptors/project/XamarinProjectDescriptor.groovy
@@ -52,11 +52,18 @@ class XamarinProjectDescriptor extends ProjectDescriptor {
 
     // Commons
 
-    String getOutputDir(String configuration, String platform = null) {
+    String getOutputDir(String configuration, String platform = null, String target = null) {
         def outputPath = getPropertyGroup(configuration, platform)?.OutputPath?.toString()
 
         if (!StringUtils.isNullOrWhiteSpace(outputPath)) {
+            if(!StringUtils.isNullOrWhiteSpace(target)){
+                outputPath = outputPath.concat("/${target}");
+            }
             return FileUtils.toUnixPath(outputPath)
+        }
+
+        if(!StringUtils.isNullOrWhiteSpace(target)){
+            return FileUtils.toUnixPath("bin/${configuration}/${target}")
         }
 
         def targetFramework = getPropertyGroup(configuration, platform)?.TargetFramework?.toString()
@@ -72,12 +79,12 @@ class XamarinProjectDescriptor extends ProjectDescriptor {
         return null
     }
 
-    Path getLibraryOutputPath(String configuration) {
-        return path.parent.resolve(getOutputDir(configuration, 'AnyCPU')).resolve("${assemblyName}.dll")
+    Path getLibraryOutputPath(String configuration, String target = null) {
+        return path.parent.resolve(getOutputDir(configuration, 'AnyCPU', target)).resolve("${assemblyName}.dll")
     }
 
-    Path getSymbolsOutputPath(String configuration, SymbolsFormat symbolsFormat = SymbolsFormat.MDB) {
-        return path.parent.resolve(getOutputDir(configuration, 'AnyCPU'))
+    Path getSymbolsOutputPath(String configuration, String target, SymbolsFormat symbolsFormat = SymbolsFormat.MDB) {
+        return path.parent.resolve(getOutputDir(configuration, 'AnyCPU', target))
                 .resolve("${assemblyName}.${symbolsFormat.fileExtension}")
     }
 

--- a/shared/xamarin-build-tools/src/test/groovy/com/betomorrow/xamarin/descriptors/project/XamarinProjectDescriptorWithNetStandardLibTest.groovy
+++ b/shared/xamarin-build-tools/src/test/groovy/com/betomorrow/xamarin/descriptors/project/XamarinProjectDescriptorWithNetStandardLibTest.groovy
@@ -21,13 +21,23 @@ class XamarinProjectDescriptorWithNetStandardLibTest {
     }
 
     @Test
-    void testGetOutputDirForDebugReturnsDebutPath() {
+    void testGetOutputDirForDebugReturnsDebugPath() {
         assert "bin/Debug/netstandard2.0" == csproj.getOutputDir("Debug")
     }
 
     @Test
-    void testGetOutputDirForReleaseReturnsDebutPath() {
+    void testGetOutputDirForReleaseReturnsReleasePath() {
         assert "bin/Release/netstandard2.0" == csproj.getOutputDir("Release")
+    }
+
+    @Test
+    void testGetOutputDirForPortableNet45ReturnsPortableNet45Path() {
+        assert "bin/Release/portable-net45" == csproj.getOutputDir("Release", "AnyCPU", "portable-net45")
+    }
+
+    @Test
+    void testGetOutputDirForNetStandardReturnsPortableNetStandardPath() {
+        assert "bin/Release/netstandard2.0" == csproj.getOutputDir("Release", "AnyCPU", "netstandard2.0")
     }
 
 


### PR DESCRIPTION
Add target attribute for supporting multiple target frameworks.
```
        assemblies {
                target {
                    dest "lib/netstandard2.0"
                    target "netstandard2.0"
                    includes "Com.Betomorrow.OneLibrary"
                }
            
                target {
                    dest "lib/portable-net45+win8+wpa81"
                    target "portable-net45+win8+wpa81"
                    includes "Com.Betomorrow.OneLibrary"
                }
          }
```