### PR TITLE
Add a verbose property to project for commands

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=com.betomorrow.gradle
-version=1.8.0
+version=1.9.0

--- a/plugins/xamarin-application-plugin/src/main/groovy/com/betomorrow/gradle/application/context/PluginContext.groovy
+++ b/plugins/xamarin-application-plugin/src/main/groovy/com/betomorrow/gradle/application/context/PluginContext.groovy
@@ -27,16 +27,18 @@ class PluginContext {
 
     static void configure(Project project) {
         boolean  dryRun = project.hasProperty("dryRun") && project.dryRun
-        instance = dryRun ? fakeApplicationContext(project) : realApplicationContext(project)
+        boolean verbose = project.hasProperty("verbose") && project.verbose
+        instance = dryRun ? fakeApplicationContext(project, verbose) : realApplicationContext(project, verbose)
     }
 
-    private static ApplicationContext fakeApplicationContext(Project project) {
+    private static ApplicationContext fakeApplicationContext(Project project, boolean verbose) {
 
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new FakeCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {
@@ -59,12 +61,13 @@ class PluginContext {
 
     }
 
-    private static ApplicationContext realApplicationContext(Project project) {
+    private static ApplicationContext realApplicationContext(Project project, boolean verbose) {
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new SystemCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {

--- a/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/context/PluginContext.groovy
+++ b/plugins/xamarin-library-plugin/src/main/groovy/com/betomorrow/gradle/library/context/PluginContext.groovy
@@ -18,15 +18,17 @@ class PluginContext {
 
     static void configure(Project project) {
         boolean  dryRun = project.hasProperty("dryRun") && project.dryRun
-        instance = dryRun ? fakeApplicationContext(project) : realApplicationContext(project)
+        boolean verbose = project.hasProperty("verbose") && project.verbose
+        instance = dryRun ? fakeApplicationContext(project, verbose) : realApplicationContext(project, verbose)
     }
 
-    private static ApplicationContext realApplicationContext(Project project) {
+    private static ApplicationContext realApplicationContext(Project project, boolean verbose) {
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new SystemCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {
@@ -42,12 +44,13 @@ class PluginContext {
                 getNuget : { nugetInstance }] as ApplicationContext
     }
 
-    private static ApplicationContext fakeApplicationContext(Project project) {
+    private static ApplicationContext fakeApplicationContext(Project project, boolean verbose) {
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new FakeCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {

--- a/plugins/xamarin-nunit-plugin/src/main/groovy/com/betomorrow/gradle/nunit/context/PluginContext.groovy
+++ b/plugins/xamarin-nunit-plugin/src/main/groovy/com/betomorrow/gradle/nunit/context/PluginContext.groovy
@@ -20,15 +20,17 @@ class PluginContext {
 
     static void configure(Project project) {
         boolean  dryRun = project.hasProperty("dryRun") && project.dryRun
-        instance = dryRun ? fakeApplicationContext(project) : realApplicationContext(project)
+        boolean verbose = project.hasProperty("verbose") && project.verbose
+        instance = dryRun ? fakeApplicationContext(project, verbose) : realApplicationContext(project, verbose)
     }
 
-    private static ApplicationContext fakeApplicationContext(Project project) {
+    private static ApplicationContext fakeApplicationContext(Project project, boolean verbose) {
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new FakeCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {
@@ -45,12 +47,13 @@ class PluginContext {
                 getNuget : { nugetInstance }] as ApplicationContext
     }
 
-    private static ApplicationContext realApplicationContext(Project project) {
+    private static ApplicationContext realApplicationContext(Project project, boolean verbose) {
         String msBuildPath = project.hasProperty("msbuildPath") ? project.property("msbuildPath") : null
         String nugetPath = project.hasProperty("nugetPath") ? project.property("nugetPath") : null
         String nugetVersion = project.hasProperty("nugetVersion") ? project.property("nugetVersion") : null
 
         CommandRunner commandRunnerInstance = new SystemCommandRunner()
+        commandRunnerInstance.verbose = verbose
 
         NugetBuilder nugetBuilder = new NugetBuilder().withCommandRunner(commandRunnerInstance)
         if (nugetPath) {

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/CommandRunner.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/CommandRunner.groovy
@@ -2,6 +2,8 @@ package com.betomorrow.xamarin.commands
 
 interface CommandRunner {
 
+    void setVerbose(boolean verbose)
+
     int run(Cmd cmd)
 
     interface Cmd {

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/DefaultCommandRunner.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/DefaultCommandRunner.groovy
@@ -11,6 +11,12 @@ class DefaultCommandRunner implements CommandRunner {
     boolean dryRun
 
     @Override
+    void setVerbose(boolean verbose) {
+        systemCommandRunner.setVerbose(verbose)
+        dryRunCommandRunner.setVerbose(verbose)
+    }
+
+    @Override
     int run(CommandRunner.Cmd cmd) {
         if (dryRun) {
             return dryRunCommandRunner.run(cmd)

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/FakeCommandRunner.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/FakeCommandRunner.groovy
@@ -4,9 +4,18 @@ class FakeCommandRunner implements CommandRunner {
 
     List<CommandRunner.Cmd> executedCommands = []
 
+    private boolean verbose
+
+    @Override
+    void setVerbose(boolean verbose) {
+        this.verbose = verbose
+    }
+
     @Override
     int run(CommandRunner.Cmd cmd) {
-        println "Execute command : ${cmd.build().join(" ")}"
+        if (verbose) {
+            println "Execute command : ${cmd.build().join(" ")}"
+        }
         executedCommands.add(cmd)
         return 1
     }

--- a/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/SystemCommandRunner.groovy
+++ b/shared/xamarin-build-tools/src/main/groovy/com/betomorrow/xamarin/commands/SystemCommandRunner.groovy
@@ -4,9 +4,18 @@ class SystemCommandRunner implements CommandRunner {
 
     def workingDirectory =  new File(System.properties['user.dir'].toString())
 
+    private boolean verbose
+
+    @Override
+    void setVerbose(boolean verbose) {
+        this.verbose = verbose
+    }
+
     @Override
     int run(CommandRunner.Cmd cmd) {
-        println "Execute command : ${cmd.build().join(" ")}"
+        if (verbose) {
+            println "Execute command : ${cmd.build().join(" ")}"
+        }
 
         StringBuilder out = new StringBuilder()
         StringBuilder err = new StringBuilder()


### PR DESCRIPTION
In the current version of the plugin, commands are printed to the console before being executed.
This can be problematic for the `nuget push` command because credentials are visible in console (or in logs when executing library deployment from CI).

To prevent security issues, I have created a new option `verbose` to choose if we want to print commands or not. Its default value is false.

We can set the option in `build.gradle`file like in this example :
```
ext {
    verbose = true
}
```
or call the command with the property :
```
gradle deploy -Pverbose=true
```